### PR TITLE
feat: add show/hide toggle for items in public catalog

### DIFF
--- a/SUPABASE_SETUP.sql
+++ b/SUPABASE_SETUP.sql
@@ -93,11 +93,13 @@ CREATE TABLE IF NOT EXISTS "public"."found_items" (
     "created_at" timestamp with time zone DEFAULT "now"(),
     "updated_at" timestamp with time zone DEFAULT "now"(),
     "high_value" boolean DEFAULT false NOT NULL,
+    "show_in_public_catalog" boolean DEFAULT true NOT NULL,
     CONSTRAINT "found_items_pkey" PRIMARY KEY ("id"),
     CONSTRAINT "found_items_status_check" CHECK (("status" = ANY (ARRAY['available'::"text", 'claimed'::"text", 'returned'::"text"])))
 );
 
 COMMENT ON COLUMN "public"."found_items"."high_value" IS 'Labels an item as high value';
+COMMENT ON COLUMN "public"."found_items"."show_in_public_catalog" IS 'When true, item appears in public browse/search. When false, hidden from catalog but still included in lost-item matching.';
 
 CREATE TABLE IF NOT EXISTS "public"."lost_item_reports" (
     "id" "uuid" DEFAULT "extensions"."uuid_generate_v4"() NOT NULL,

--- a/package-lock.json
+++ b/package-lock.json
@@ -527,23 +527,6 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
-      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openharmony-arm64": {
       "version": "0.27.2",
       "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.2.tgz",
       "integrity": "sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==",
@@ -3379,6 +3362,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.16.5.tgz",
       "integrity": "sha512-bJFoMATwIGaxxx8VJPeM8TonI8t579oRvgAuT8zFugJsJZgzqv0Fu8Mhp68iecjzG7cnN3mO2dJQ5uUM2EFrgQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -5233,6 +5217,23 @@
       "optional": true,
       "os": [
         "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
       ],
       "engines": {
         "node": ">=18"
@@ -8947,6 +8948,7 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",

--- a/src/app/components/admin/AddItemModal.tsx
+++ b/src/app/components/admin/AddItemModal.tsx
@@ -12,6 +12,8 @@ import { Upload, Camera, X, Loader2, ChevronRight, ChevronLeft, QrCode, Link as 
 import { useToast } from '@/hooks/use-toast';
 import { deleteImage, uploadImage } from '../../.././lib/database';
 import { mapCategory } from '../../data/categoryMap';
+import { shouldDefaultHidden } from '@/lib/catalogVisibility';
+import { Switch } from '@/components/ui/switch';
 
 interface AddItemModalProps {
   open: boolean;
@@ -28,6 +30,7 @@ interface AddItemModalProps {
     brand?: string;
     foundDate?: string;
     highValue?: boolean;
+    showInPublicCatalog?: boolean;
   }>;
   onSubmit: (data: {
     name: string;
@@ -39,6 +42,7 @@ interface AddItemModalProps {
     brand?: string;
     foundDate?: string;
     highValue?: boolean;
+    showInPublicCatalog?: boolean;
   }) => Promise<void> | void;
 }
 
@@ -75,6 +79,7 @@ const initialFormState = () => ({
   brand: '',
   foundDate: todayLocalISO(),
   highValue: false,
+  showInPublicCatalog: true,
 });
 
 // Browsers can't render HEIC/HEIF; allow only PNG/JPEG
@@ -274,6 +279,11 @@ export function AddItemModal({ open, onOpenChange, onSubmit, initialData, staffI
           if (!prev.foundLocation?.trim() && data.foundLocation) next.foundLocation = data.foundLocation;
           if (!prev.foundDate?.trim() && data.foundDate && /^\d{4}-\d{2}-\d{2}$/.test(data.foundDate)) next.foundDate = data.foundDate;
           if (data.highValue === true) next.highValue = true;
+          next.showInPublicCatalog = !shouldDefaultHidden(
+            (next.category || prev.category) as ItemCategory,
+            next.name || prev.name,
+            next.description || prev.description
+          );
           return next;
         });
         toast({ title: 'AI analysis applied', description: 'Fields were pre-filled. Please verify before submitting.' });
@@ -340,6 +350,7 @@ export function AddItemModal({ open, onOpenChange, onSubmit, initialData, staffI
         brand: formData.brand || undefined,
         foundDate: formData.foundDate,
         highValue: formData.highValue,
+        showInPublicCatalog: formData.showInPublicCatalog,
       });
       handleOpenChange(false, { keepImage: true });
     } catch (e) {
@@ -437,6 +448,16 @@ export function AddItemModal({ open, onOpenChange, onSubmit, initialData, staffI
     };
   }, [formData.imageUrl]);
 
+  // Auto-default showInPublicCatalog to hidden when item is "expensive" (reduces staff clicks)
+  // Only auto-set to hidden; never auto-set to true (user may have chosen to show)
+  useEffect(() => {
+    if (!open) return;
+    const defaultHidden = shouldDefaultHidden(formData.category, formData.name, formData.description);
+    if (defaultHidden) {
+      setFormData((prev) => (prev.showInPublicCatalog ? { ...prev, showInPublicCatalog: false } : prev));
+    }
+  }, [open, formData.category, formData.name, formData.description]);
+
   // sync initialData into form only when modal opens / initialData changes
   useEffect(() => {
     if (!open || !initialData) return;
@@ -452,6 +473,7 @@ export function AddItemModal({ open, onOpenChange, onSubmit, initialData, staffI
       brand: initialData.brand ?? prev.brand,
       foundDate: initialData.foundDate ?? prev.foundDate,
       highValue: initialData.highValue ?? prev.highValue,
+      showInPublicCatalog: initialData.showInPublicCatalog ?? prev.showInPublicCatalog,
     }));
   }, [open, initialData]);
 
@@ -724,6 +746,18 @@ export function AddItemModal({ open, onOpenChange, onSubmit, initialData, staffI
                   className="bg-background border-border/50"
                 />
               </div>
+
+              <div className="col-span-2 flex items-center justify-between rounded-lg border border-border/50 p-4 bg-muted/20">
+                <div>
+                  <Label htmlFor="showInPublicCatalog" className="text-sm font-medium">Show in public catalog</Label>
+                  <p className="text-xs text-muted-foreground mt-1">When off, item is hidden from browse/search but still appears in lost-item matching.</p>
+                </div>
+                <Switch
+                  id="showInPublicCatalog"
+                  checked={formData.showInPublicCatalog}
+                  onCheckedChange={(checked) => setFormData((p) => ({ ...p, showInPublicCatalog: !!checked }))}
+                />
+              </div>
             </div>
 
             <div className="flex gap-3 justify-end pt-4">
@@ -752,6 +786,7 @@ export function AddItemModal({ open, onOpenChange, onSubmit, initialData, staffI
                 <div><span className="text-muted-foreground">Category:</span> <span className="font-medium">{categoryLabels[formData.category]}</span></div>
                 {formData.imagePreview && <div><span className="text-muted-foreground">Photo:</span> <span className="font-medium">Yes</span></div>}
                 {formData.highValue && <div><span className="text-destructive">High Value Item</span></div>}
+                <div><span className="text-muted-foreground">Show in catalog:</span> <span className="font-medium">{formData.showInPublicCatalog ? 'Yes' : 'No (hidden)'}</span></div>
               </div>
             </div>
 

--- a/src/app/components/admin/AdminItemCard.tsx
+++ b/src/app/components/admin/AdminItemCard.tsx
@@ -8,7 +8,8 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { Calendar, MoreVertical, Eye, CheckCircle, Trash2 } from "lucide-react";
+import { Switch } from "@/components/ui/switch";
+import { Calendar, MoreVertical, Eye, EyeOff, CheckCircle, Trash2 } from "lucide-react";
 
 interface AdminItemCardProps {
   item: FoundItem;
@@ -16,9 +17,10 @@ interface AdminItemCardProps {
   onClose: (item: FoundItem) => void; // we’ll use this as “Mark Returned”
   onCancel: (item: FoundItem) => void; // we’ll use this as “Delete”
   onView: (item: FoundItem) => void; // kept for compatibility (you can no-op it)
+  onToggleCatalogVisibility?: (item: FoundItem) => void;
 }
 
-export function AdminItemCard({ item, onEdit, onClose, onCancel, onView }: AdminItemCardProps) {
+export function AdminItemCard({ item, onEdit, onClose, onCancel, onView, onToggleCatalogVisibility }: AdminItemCardProps) {
   const statusStyles: Record<string, string> = {
     available: "bg-primary/15 text-primary border-primary/30",
     returned: "bg-muted text-muted-foreground border-border",
@@ -49,9 +51,17 @@ export function AdminItemCard({ item, onEdit, onClose, onCancel, onView }: Admin
                 <p className="text-xs text-muted-foreground truncate">{item.description}</p>
               </div>
 
-              <Badge variant="outline" className={`${badgeClass} flex-shrink-0 text-xs capitalize`}>
-                {item.status}
-              </Badge>
+              <div className="flex items-center gap-1.5 flex-shrink-0">
+                {item.showInPublicCatalog === false && (
+                  <Badge variant="secondary" className="text-xs bg-amber-500/15 text-amber-700 dark:text-amber-400 border-amber-500/30">
+                    <EyeOff className="w-3 h-3 mr-0.5" />
+                    Hidden
+                  </Badge>
+                )}
+                <Badge variant="outline" className={`${badgeClass} text-xs capitalize`}>
+                  {item.status}
+                </Badge>
+              </div>
             </div>
 
             <div className="flex items-center justify-between mt-2">
@@ -64,6 +74,18 @@ export function AdminItemCard({ item, onEdit, onClose, onCancel, onView }: Admin
                   {new Date(item.dateFound).toLocaleDateString()}
                 </span>
               </div>
+
+              <div className="flex items-center gap-2">
+                {item.status === "available" && onToggleCatalogVisibility && (
+                  <div className="flex items-center gap-1.5" onClick={(e) => e.stopPropagation()}>
+                    <span className="text-xs text-muted-foreground hidden sm:inline">Catalog</span>
+                    <Switch
+                      checked={item.showInPublicCatalog !== false}
+                      onCheckedChange={() => onToggleCatalogVisibility(item)}
+                      className="scale-75"
+                    />
+                  </div>
+                )}
 
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
@@ -103,6 +125,7 @@ export function AdminItemCard({ item, onEdit, onClose, onCancel, onView }: Admin
                   </DropdownMenuItem>
                 </DropdownMenuContent>
               </DropdownMenu>
+              </div>
             </div>
           </div>
         </div>

--- a/src/app/lib/catalogVisibility.ts
+++ b/src/app/lib/catalogVisibility.ts
@@ -1,0 +1,54 @@
+import type { ItemCategory } from "@/types";
+
+// Categories that default to hidden (not shown in public catalog) when adding items
+const CATEGORIES_DEFAULT_HIDDEN: ItemCategory[] = [
+  "accessories",
+  "bags",
+  "documents",
+  "keys",
+];
+
+// For electronics: only default to hidden when name/description contains these keywords
+const EXPENSIVE_ELECTRONICS_KEYWORDS = [
+  "laptop",
+  "laptops",
+  "airpods",
+  "air pods",
+  "ipad",
+  "ipads",
+  "phone",
+  "iphone",
+  "smartphone",
+  "smart phone",
+  "macbook",
+  "computer",
+  "tablet",
+  "watch", // Apple Watch etc.
+  "headphones",
+  "earbuds",
+  "ear buds",
+];
+
+/**
+ * Returns true if the item should default to hidden (show_in_public_catalog = false)
+ * based on category and optional name/description.
+ */
+export function shouldDefaultHidden(
+  category: ItemCategory,
+  name?: string,
+  description?: string
+): boolean {
+  const text = [name ?? "", description ?? ""].join(" ").toLowerCase();
+
+  // Non-electronics: category alone determines default
+  if (CATEGORIES_DEFAULT_HIDDEN.includes(category)) {
+    return true;
+  }
+
+  // Electronics: category + keywords
+  if (category === "electronics") {
+    return EXPENSIVE_ELECTRONICS_KEYWORDS.some((kw) => text.includes(kw));
+  }
+
+  return false;
+}

--- a/src/app/pages/AdminDashboard.tsx
+++ b/src/app/pages/AdminDashboard.tsx
@@ -32,6 +32,7 @@ import { Input } from "@/components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Switch } from "@/components/ui/switch";
 
 import type { FoundItem, ItemFormData } from "@/types";
 import { categoryLabels } from "@/types";
@@ -68,6 +69,7 @@ function rowToFoundItem(row: any, profile: any): FoundItem {
     updatedAt: String(row?.updated_at ?? row?.created_at ?? new Date().toISOString()),
     color: row?.color ?? undefined,
     brand: row?.brand ?? undefined,
+    showInPublicCatalog: row?.show_in_public_catalog !== false,
   };
 }
 
@@ -204,7 +206,7 @@ export default function AdminDashboard() {
     return filtered;
   }, [items, searchQuery, categoryFilter, statusFilter, sortBy]);
 
-  async function handleCreate(data: ItemFormData & { highValue?: boolean }) {
+  async function handleCreate(data: ItemFormData & { highValue?: boolean; showInPublicCatalog?: boolean }) {
     try {
 
       // Your DB expects found_items columns (item_name, found_location, etc.)
@@ -219,6 +221,7 @@ export default function AdminDashboard() {
         color: data.color ?? null,
         image_urls: data.imageUrl ? [data.imageUrl] : [],
         high_value: data.highValue ? true : false,
+        show_in_public_catalog: data.showInPublicCatalog !== false,
         status: "available",
       });
 
@@ -233,6 +236,24 @@ export default function AdminDashboard() {
       toast({
         title: "Create failed",
         description: err?.message ?? "Could not create item",
+        variant: "destructive",
+      });
+    }
+  }
+
+  async function handleToggleCatalogVisibility(item: FoundItem) {
+    const next = !item.showInPublicCatalog;
+    try {
+      await updateFoundItem(item.id, { show_in_public_catalog: next });
+      setItems((prev) => prev.map((x) => (x.id === item.id ? { ...x, showInPublicCatalog: next } : x)));
+      toast({
+        title: next ? "Item now visible" : "Item hidden from catalog",
+        description: next ? `${item.name} will appear in public browse/search.` : `${item.name} is hidden from browse/search but still appears in matching.`,
+      });
+    } catch (err: any) {
+      toast({
+        title: "Update failed",
+        description: err?.message ?? "Could not update visibility",
         variant: "destructive",
       });
     }
@@ -466,6 +487,7 @@ export default function AdminDashboard() {
                     onClose={handleClose}
                     onCancel={handleCancel}
                     onView={handleView}
+                    onToggleCatalogVisibility={handleToggleCatalogVisibility}
                   />
                 ))}
               </div>
@@ -526,6 +548,25 @@ export default function AdminDashboard() {
                       <span>By: {selectedItem.checkedInBy}</span>
                     </div>
                   </div>
+                  {selectedItem.status === 'available' && (
+                    <div className="flex items-center justify-between rounded-lg border border-border/50 p-3 bg-muted/20">
+                      <div>
+                        <p className="text-sm font-medium">Show in public catalog</p>
+                        <p className="text-xs text-muted-foreground">
+                          {selectedItem.showInPublicCatalog !== false
+                            ? 'Visible in browse/search'
+                            : 'Hidden from browse/search (still in matching)'}
+                        </p>
+                      </div>
+                      <Switch
+                        checked={selectedItem.showInPublicCatalog !== false}
+                        onCheckedChange={() => {
+                          handleToggleCatalogVisibility(selectedItem);
+                          setSelectedItem((prev) => prev ? { ...prev, showInPublicCatalog: !prev.showInPublicCatalog } : null);
+                        }}
+                      />
+                    </div>
+                  )}
                 </div>
                 <div className="flex gap-2 pt-4">
                   {selectedItem.status === 'available' && (

--- a/src/app/types/index.ts
+++ b/src/app/types/index.ts
@@ -28,6 +28,7 @@ export interface FoundItem {
   updatedAt?: string;
   color?: string;
   brand?: string;
+  showInPublicCatalog?: boolean;
 }
 
 export interface ItemFormData {

--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -26,6 +26,7 @@ export interface FoundItemRow {
   current_location?: string | null;
   image_urls?: string[] | null;
   status?: FoundItemStatus;
+  show_in_public_catalog?: boolean;
   created_at?: string;
   [k: string]: unknown;
 }
@@ -40,6 +41,7 @@ export interface CreateFoundItemInput {
   current_location?: string;
   image_urls?: string[];
   status?: FoundItemStatus;
+  show_in_public_catalog?: boolean;
   [k: string]: unknown;
 }
 
@@ -125,6 +127,7 @@ export const getFoundItems = async (limit = 20, offset = 0): Promise<FoundItemRo
     `
     )
     .eq("status", "available")
+    .eq("show_in_public_catalog", true)
     .order("created_at", { ascending: false })
     .range(offset, offset + limit - 1);
 
@@ -165,7 +168,8 @@ export const searchFoundItems = async (
       )
     `
     )
-    .eq("status", "available");
+    .eq("status", "available")
+    .eq("show_in_public_catalog", true);
 
   if (category) query = query.eq("category", category);
 

--- a/supabase/migrations/20260228000000_add_show_in_public_catalog.sql
+++ b/supabase/migrations/20260228000000_add_show_in_public_catalog.sql
@@ -1,0 +1,8 @@
+-- Add show_in_public_catalog column to found_items
+-- When false: item is hidden from public browse/search but still appears in matching
+-- Existing items default to true (visible) for backward compatibility
+
+ALTER TABLE "public"."found_items"
+ADD COLUMN IF NOT EXISTS "show_in_public_catalog" boolean DEFAULT true NOT NULL;
+
+COMMENT ON COLUMN "public"."found_items"."show_in_public_catalog" IS 'When true, item appears in public browse/search. When false, hidden from catalog but still included in lost-item matching.';


### PR DESCRIPTION
- Add show_in_public_catalog column to found_items (migration)
- Staff can toggle visibility when adding/editing items
- Auto-default hidden for expensive categories (electronics, accessories, bags, documents, keys)
- Electronics also uses keywords (laptop, airpods, phone, etc.)
- Hidden items excluded from browse/search but still in matching
- Admin dashboard shows Hidden badge and catalog toggle per item

Made-with: Cursor