### PR TITLE
fix(matches)

### DIFF
--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -541,7 +541,7 @@ export const getClaimsForItem = async (foundItemId: string): Promise<any[]> => {
     .select(
       `
       *,
-      student:profiles!student_id(
+      student:profiles!claimant_id(
         full_name,
         email,
         phone_number,
@@ -708,11 +708,14 @@ export const findPotentialMatches = async (lostItemData: Partial<LostItemReportR
     .select(
       `
       *,
-      office:offices!office_id(
-        office_id,
-        office_name,
-        building_name,
-        office_address
+      staff:profiles!staff_id(
+        full_name,
+        office:offices!office_id(
+          office_id,
+          office_name,
+          building_name,
+          office_address
+        )
       )
     `
     )


### PR DESCRIPTION
correct invalid FK join paths in findPotentialMatches and getClaimsForItem

- findPotentialMatches: replaced direct offices!office_id join (no FK constraint exists between found_items and offices) with the correct two-hop path via staff:profiles!staff_id -> office:offices!office_id, consistent with all other queries in the file.

- getClaimsForItem: replaced profiles!student_id (column does not exist on claims) with profiles!claimant_id, matching the actual FK constraint claims_claimant_id_fkey.